### PR TITLE
Add optional asset_dotenv input to asset builder apps

### DIFF
--- a/asset_builder.py
+++ b/asset_builder.py
@@ -98,22 +98,27 @@ def get_system_snapshot(output_file_path, ignore_files):
         proc.communicate()
 
 
-def build_asset(conf_json_fh, asset_makefile_fh, custom_asset_fh):
+def build_asset(conf_json_fh, asset_makefile_fh, asset_dotenv_fh, custom_asset_fh):
     conf_json_fh = dxpy.DXFile(conf_json_fh)
 
     if asset_makefile_fh is not None:
         asset_makefile_fh = dxpy.DXFile(asset_makefile_fh)
+    if asset_dotenv_fh is not None:
+        asset_dotenv_fh = dxpy.DXFile(asset_dotenv_fh)
     if custom_asset_fh is not None:
         custom_asset_fh = dxpy.DXFile(custom_asset_fh)
 
     asset_conffile_path = "assetLib.json"
     custom_assetfile_path = "asset-dl.tar.gz"
     asset_makefile_path = "Makefile"
+    asset_dotenv_path = ".env"
 
     dxpy.download_dxfile(conf_json_fh, asset_conffile_path)
 
     if asset_makefile_fh is not None:
         dxpy.download_dxfile(asset_makefile_fh, asset_makefile_path)
+    if asset_dotenv_fh is not None:
+        dxpy.download_dxfile(asset_dotenv_fh, asset_dotenv_path)
     if custom_asset_fh is not None:
         dxpy.download_dxfile(custom_asset_fh, custom_assetfile_path)
 

--- a/asset_builder_py3.py
+++ b/asset_builder_py3.py
@@ -102,22 +102,27 @@ def get_system_snapshot(output_file_path, ignore_files):
         proc.communicate()
 
 
-def build_asset(conf_json_fh, asset_makefile_fh, custom_asset_fh):
+def build_asset(conf_json_fh, asset_makefile_fh, asset_dotenv_fh, custom_asset_fh):
     conf_json_fh = dxpy.DXFile(conf_json_fh)
 
     if asset_makefile_fh is not None:
         asset_makefile_fh = dxpy.DXFile(asset_makefile_fh)
+    if asset_dotenv_fh is not None:
+        asset_dotenv_fh = dxpy.DXFile(asset_dotenv_fh)
     if custom_asset_fh is not None:
         custom_asset_fh = dxpy.DXFile(custom_asset_fh)
 
     asset_conffile_path = "assetLib.json"
     custom_assetfile_path = "asset-dl.tar.gz"
     asset_makefile_path = "Makefile"
+    asset_dotenv_path = ".env"
 
     dxpy.download_dxfile(conf_json_fh, asset_conffile_path)
 
     if asset_makefile_fh is not None:
         dxpy.download_dxfile(asset_makefile_fh, asset_makefile_path)
+    if asset_dotenv_fh is not None:
+        dxpy.download_dxfile(asset_dotenv_fh, asset_dotenv_path)
     if custom_asset_fh is not None:
         dxpy.download_dxfile(custom_asset_fh, custom_assetfile_path)
 

--- a/create_asset_focal/create_asset_focal.py
+++ b/create_asset_focal/create_asset_focal.py
@@ -8,7 +8,7 @@ import asset_builder_py3 as asset_builder
 
 
 @dxpy.entry_point('main')
-def main(conf_json, asset_makefile=None, custom_asset=None):
-    return asset_builder.build_asset(conf_json, asset_makefile, custom_asset)
+def main(conf_json, asset_makefile=None, asset_dotenv=None, custom_asset=None):
+    return asset_builder.build_asset(conf_json, asset_makefile, asset_dotenv, custom_asset)
 
 dxpy.run()

--- a/create_asset_focal/dxapp.json
+++ b/create_asset_focal/dxapp.json
@@ -20,6 +20,13 @@
       "optional": true
     },
     {
+      "name": "asset_dotenv",
+      "label": "A .env file that can be loaded by the Makefile",
+      "class": "file",
+      "optional": true,
+      "patterns": [".env"]
+    },
+    {
       "name": "custom_asset",
       "label": "An archive file (tar.gz) containing custom assets",
       "class": "file",

--- a/create_asset_precise/create_asset_precise.py
+++ b/create_asset_precise/create_asset_precise.py
@@ -8,7 +8,7 @@ import asset_builder
 
 
 @dxpy.entry_point('main')
-def main(conf_json, asset_makefile=None, custom_asset=None):
-    return asset_builder.build_asset(conf_json, asset_makefile, custom_asset)
+def main(conf_json, asset_makefile=None, asset_dotenv=None, custom_asset=None):
+    return asset_builder.build_asset(conf_json, asset_makefile, asset_dotenv, custom_asset)
 
 dxpy.run()

--- a/create_asset_precise/dxapp.json
+++ b/create_asset_precise/dxapp.json
@@ -20,6 +20,13 @@
       "optional": true
     },
     {
+      "name": "asset_dotenv",
+      "label": "A .env file that can be loaded by the Makefile",
+      "class": "file",
+      "optional": true,
+      "patterns": [".env"]
+    },
+    {
       "name": "custom_asset",
       "label": "An archive file (tar.gz) containing custom assets",
       "class": "file",

--- a/create_asset_trusty/create_asset_trusty.py
+++ b/create_asset_trusty/create_asset_trusty.py
@@ -8,7 +8,7 @@ import asset_builder
 
 
 @dxpy.entry_point('main')
-def main(conf_json, asset_makefile=None, custom_asset=None):
-    return asset_builder.build_asset(conf_json, asset_makefile, custom_asset)
+def main(conf_json, asset_makefile=None, asset_dotenv=None, custom_asset=None):
+    return asset_builder.build_asset(conf_json, asset_makefile, asset_dotenv, custom_asset)
 
 dxpy.run()

--- a/create_asset_trusty/dxapp.json
+++ b/create_asset_trusty/dxapp.json
@@ -20,6 +20,13 @@
       "optional": true
     },
     {
+      "name": "asset_dotenv",
+      "label": "A .env file that can be loaded by the Makefile",
+      "class": "file",
+      "optional": true,
+      "patterns": [".env"]
+    },
+    {
       "name": "custom_asset",
       "label": "An archive file (tar.gz) containing custom assets",
       "class": "file",

--- a/create_asset_xenial/create_asset_xenial.py
+++ b/create_asset_xenial/create_asset_xenial.py
@@ -8,7 +8,7 @@ import asset_builder
 
 
 @dxpy.entry_point('main')
-def main(conf_json, asset_makefile=None, custom_asset=None):
-    return asset_builder.build_asset(conf_json, asset_makefile, custom_asset)
+def main(conf_json, asset_makefile=None, asset_dotenv=None, custom_asset=None):
+    return asset_builder.build_asset(conf_json, asset_makefile, asset_dotenv, custom_asset)
 
 dxpy.run()

--- a/create_asset_xenial/dxapp.json
+++ b/create_asset_xenial/dxapp.json
@@ -20,6 +20,13 @@
       "optional": true
     },
     {
+      "name": "asset_dotenv",
+      "label": "A .env file that can be loaded by the Makefile",
+      "class": "file",
+      "optional": true,
+      "patterns": [".env"]
+    },
+    {
       "name": "custom_asset",
       "label": "An archive file (tar.gz) containing custom assets",
       "class": "file",

--- a/create_asset_xenial_v1/create_asset_xenial_v1.py
+++ b/create_asset_xenial_v1/create_asset_xenial_v1.py
@@ -8,7 +8,7 @@ import asset_builder_py3 as asset_builder
 
 
 @dxpy.entry_point('main')
-def main(conf_json, asset_makefile=None, custom_asset=None):
-    return asset_builder.build_asset(conf_json, asset_makefile, custom_asset)
+def main(conf_json, asset_makefile=None, asset_dotenv=None, custom_asset=None):
+    return asset_builder.build_asset(conf_json, asset_makefile, asset_dotenv, custom_asset)
 
 dxpy.run()

--- a/create_asset_xenial_v1/dxapp.json
+++ b/create_asset_xenial_v1/dxapp.json
@@ -20,6 +20,13 @@
       "optional": true
     },
     {
+      "name": "asset_dotenv",
+      "label": "A .env file that can be loaded by the Makefile",
+      "class": "file",
+      "optional": true,
+      "patterns": [".env"]
+    },
+    {
       "name": "custom_asset",
       "label": "An archive file (tar.gz) containing custom assets",
       "class": "file",


### PR DESCRIPTION
Adds an optional `asset_dotenv` input to all the asset builder apps. The asset builder client can now pass in a .env file that can be used by the Makefile to load environment variables that the user does not want to hard-code in the Makefile.